### PR TITLE
Remove _list from field names in file directive

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -23,7 +23,7 @@
   <directive action="sum" add="[if?:input_registration==Student Preregistration - $0.00:0:0]" total="total"/>
   <directive special="nelnet" amount="[total:total]" order_type="CONF27"/>
   <!--File - update by deleting file with test data on server before launch-->
-  <directive action="file" filename="results[timestamp:YYYY].csv" format="csv" fields="firstname,lastname,email,input_registration,input_address_state,input_address_country,date-and-time,input_role,input_generation,input_race_ethnicity_list,input_disability_status_list,input_gender_list,input_sign_language_interpreter,input_comments" />
+  <directive action="file" filename="results[timestamp:YYYY].csv" format="csv" fields="firstname,lastname,email,input_registration,input_address_state,input_address_country,date-and-time,input_role,input_generation,input_race_ethnicity,input_disability_status,input_gender,input_sign_language_interpreter,input_comments" />
   <!--Email Receipt/Notification - update to full distribution list before launch-->
   <!--directive action="email" to="hagstrom@bu.edu" from="langconf@bu.edu" subject="TESTING - BUCLD 46 Registration Notification" template="[notification_template]"> -->
   <directive action="email" to="fkpog001@bu.edu,yinggong@bu.edu,langconf@bu.edu" from="langconf@bu.edu" subject="BUCLD 46 Registration Notification" template="[notification_template]"> -->


### PR DESCRIPTION
There are several fields on the forms that are checkbox arrays, and the file directive had them specified with _list after their name (like input_gender_list, while the field id is input_gender). I don't know why it was like that, I guess I assumed it was some kind of magic that Telegraph responded to, since that one field is an array that can have several values checked. But the output file is saving nothing for those fields. So I have attempted to make the fields in the file directive match the name of the checkbox arrays instead, which I hope will cause that data to be saved. I am explaining my thought process here though in case there *is* some magic but _list isn't it.