### PR TITLE
Update prices, fix individual events bug

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -91,8 +91,10 @@
   <directive action="sum" add="[if?:input_status==General registration:35:0]" quantity="[event_quantity]" total="total" />
   <directive action="sum" add="[if?:input_status==Postbacc Trainee registration:35:0]" quantity="[event_quantity]" total="total"  />
   <!--SLD registration categories-->
-  <directive action="sum" add="[if?:input_sld==General - $20.00:20:0]" total="total"/>
-  <directive action="sum" add="[if?:input_sld==Student - $10.00:10:0]" total="total"/>
+  <directive action="sum" add="[if?:input_sld==General (not LLD subscriber) - $60.00:60:0]" total="total"/>
+  <directive action="sum" add="[if?:input_sld==General (LLD subscriber) - $25.00:25:0]" total="total"/>
+  <directive action="sum" add="[if?:input_sld==Student (not LLD subscriber) - $25.00:25:0]" total="total"/>
+  <directive action="sum" add="[if?:input_sld==Student (LLD subscriber) - $10.00:10:0]" total="total"/>
   <directive action="sum" add="[if?:input_sld==Not attending the SLD Symposium on Thursday - $0.00:0:0]" total="total"/>
   
   <directive special="nelnet" amount="[total:total]" order_type="CONF27"/>

--- a/config.xml
+++ b/config.xml
@@ -18,6 +18,7 @@
   <directive action="field" name="receipt_template" value="receipt.txt" />
   <directive action="field" name="notification_template" value="notification.txt" />
   <!--New (computed) Fields-->
+  <!--note: I don't think input_race_list or input_gender_list are actually used-->
   <directive action="field" name="individual_events_list" value="[list:input_individual_events]" />
   <directive action="field" name="input_race_list" value="[list:input_race]" />
   <directive action="field" name="input_gender_list" value="[list:input_gender]" />
@@ -26,6 +27,8 @@
   <!--Event Quantity-->
   <!--We need to account for every permutation individually, no smart sums here-->
   <!--Values here must exactly match text on form (also goes on receipts)-->
+  <!--Values here must also be IN THE SAME ORDER as the options on the form-->
+  <!--Full list: Friday Keynote, Saturday Symposium, Saturday Plenary Address, Sunday Symposium, Single Session-->
   <!--Individual events price per, really just done for display on receipts, it is computed again later for summing-->
   <!--removing Saturday symposioum from 2023 but retaining code for potential restoration in 2024-->
   <directive action="field" name="individual_events_price" value="[if?:input_status==Student registration:20:35]" />
@@ -52,8 +55,10 @@
   <!--directive action="conditional-field" source_field="individual_events_list" source_value="Friday Keynote, Saturday Symposium, Single Session" target_field="event_quantity" target_value="3"/>-->
   <directive action="conditional-field" source_field="individual_events_list" source_value="Friday Keynote, Saturday Plenary Address, Sunday Symposium " target_field="event_quantity" target_value="3"/>
   <directive action="conditional-field" source_field="individual_events_list" source_value="Friday Keynote, Saturday Plenary Address, Single Session" target_field="event_quantity" target_value="3"/>
+  <directive action="conditional-field" source_field="individual_events_list" source_value="Friday Keynote, Sunday Symposium, Single Session" target_field="event_quantity" target_value="3"/>
   <!--directive action="conditional-field" source_field="individual_events_list" source_value="Saturday Symposium, Saturday Plenary Address, Sunday Symposium" target_field="event_quantity" target_value="3"/>-->
   <!--directive action="conditional-field" source_field="individual_events_list" source_value="Saturday Symposium, Saturday Plenary Address, Single Session" target_field="event_quantity" target_value="3"/>-->
+  <!--directive action="conditional-field" source_field="individual_events_list" source_value="Saturday Symposium, Sunday Symposium, Single Session" target_field="event_quantity" target_value="3"/>-->
   <directive action="conditional-field" source_field="individual_events_list" source_value="Saturday Plenary Address, Sunday Symposium, Single Session" target_field="event_quantity" target_value="3"/>
   <!--Event Quantity: quadruples of events-->
   <!--directive action="conditional-field" source_field="individual_events_list" source_value="Friday Keynote, Saturday Symposium, Saturday Plenary Address, Sunday Symposium" target_field="event_quantity" target_value="4"/>-->
@@ -92,7 +97,7 @@
   
   <directive special="nelnet" amount="[total:total]" order_type="CONF27"/>
   <!--File - update by deleting file with test data on server before launch-->
-  <directive action="file" filename="results[timestamp:YYYY].csv" format="csv" fields="firstname,lastname,email,input_affiliation,input_pronouns,input_registration,input_status,input_select_day,input_attend,input_record,individual_events,input_student_workshop_thursday,input_student_pizza_lunch,input_sld,input_address_state,input_address_country,input_role,input_generation,input_ethnicity,input_race,input_disability,input_disability_status,input_gender,input_sign_language_interpreter,input_access_needs,input_comments,date-and-time" />
+  <directive action="file" filename="results[timestamp:YYYY].csv" format="csv" fields="firstname,lastname,email,input_affiliation,input_pronouns,input_registration,input_status,input_select_day,input_attend,input_record,individual_events_list,input_student_workshop_thursday,input_student_pizza_lunch,input_sld,input_address_state,input_address_country,input_role,input_generation,input_ethnicity,input_race,input_disability,input_disability_status,input_gender,input_sign_language_interpreter,input_access_needs,input_comments,date-and-time" />
   <!--Email Receipt/Notification - update to full distribution list before launch-->
   <directive action="email" to="hayat777@bu.edu,jupitara@bu.edu,michos@bu.edu,ocisse@bu.edu,langconf@bu.edu" from="langconf@bu.edu" subject="BUCLD 48 Registration Notification" template="[notification_template]">
   <directive action="email" to="[email],langconf@bu.edu" from="langconf@bu.edu" subject="BUCLD 48 Registration Receipt" template="[receipt_template]" />

--- a/notification-prereg.txt
+++ b/notification-prereg.txt
@@ -2,10 +2,16 @@ This BUCLD 48 registration has been submitted, and sent to the Cashier's Office 
 
 Name: [firstname] [lastname]
 Email: [email]
+Affiliation: [input_affiliation]
+Pronouns: [input_pronouns]
 
-BUCLD Registration: [input_registration]
-
+BUCLD Registration: [input_registration][newline?:input_student_workshop_thursday] [checked?:input_student_workshop_thursday][newline?:input_student_pizza_lunch] [checked?:input_student_pizza_lunch]
+ 
+SLD Registration: [input_sld]
+ 
 Comments:
+ [checked?:input_sign_language_interpreter]
+ [input_access_needs]
  [input_comments]
 
 ==Payment Information==

--- a/notification.txt
+++ b/notification.txt
@@ -2,10 +2,17 @@ This BUCLD 48 registration has been submitted, and sent to the Cashier's Office 
 
 Name: [firstname] [lastname]
 Email: [email]
+Affiliation: [input_affiliation]
+Pronouns: [input_pronouns]
 
-BUCLD Registration: [input_registration]
+BUCLD Registration: [input_registration] ([checked?:input_select_day])
+ Individual events ($[individual_events_price] each): [list:input_individual_events][newline?:input_student_workshop_thursday] [checked?:input_student_workshop_thursday][newline?:input_student_pizza_lunch] [checked?:input_student_pizza_lunch]
 
+SLD Registration: [input_sld]
+ 
 Comments:
+ [checked?:input_sign_language_interpreter]
+ [input_access_needs]
  [input_comments]
 
 ==Payment Information==

--- a/receipt-prereg.txt
+++ b/receipt-prereg.txt
@@ -22,7 +22,7 @@ Your registrant information is as follows:
 Name: [firstname] [lastname]
 Email: [email]
 Affiliation: [input_affiliation]
-Social media for badge: [input_twitter]
+Pronouns: [input_pronouns]
 
 BUCLD Registration: [input_registration][newline?:input_student_workshop_thursday] [checked?:input_student_workshop_thursday][newline?:input_student_pizza_lunch] [checked?:input_student_pizza_lunch]
 

--- a/receipt.txt
+++ b/receipt.txt
@@ -22,7 +22,7 @@ Your registrant information is as follows:
 Name: [firstname] [lastname]
 Email: [email]
 Affiliation: [input_affiliation]
-Social media for badge: [input_twitter]
+Pronouns: [input_pronouns]
 
 BUCLD Registration: [input_registration] ([checked?:input_select_day])
  Individual events ($[individual_events_price] each): [list:input_individual_events][newline?:input_student_workshop_thursday] [checked?:input_student_workshop_thursday][newline?:input_student_pizza_lunch] [checked?:input_student_pizza_lunch]


### PR DESCRIPTION
One combination of individual events was not properly checked and so was not adding to the total. Fixed ordering anomaly with the individual events as well, now in sync with the submission form.

Save individual_events_list to the file rather than individual_events (alternative would be input_individual_events, either should work—but individual_events won't, it is not defined).

Templates updated to reflect pronouns (used to be "twitter")